### PR TITLE
build and run in linux

### DIFF
--- a/c_src/js.h
+++ b/c_src/js.h
@@ -13,6 +13,7 @@
 #ifndef ATELES_JS_H
 #define ATELES_JS_H
 
+#include <vector>
 #include <future>
 
 #include "js/Initialization.h"


### PR DESCRIPTION
This PR is to address the build issue in linux:

```
In file included from /usr/local/ateles/c_src/js.cc:13:
/usr/local/ateles/c_src/js.h:46:54: error: no template named 'vector' in namespace 'std'
    std::string eval(const std::string& script, std::vector<std::string>& args);
                                                ~~~~~^
/usr/local/ateles/c_src/js.h:47:52: error: no template named 'vector' in namespace 'std'
    std::string call(const std::string& name, std::vector<std::string>& args);
                                              ~~~~~^
/usr/local/ateles/c_src/js.cc:136:16: error: out-of-line definition of 'eval' does not match any declaration in 'ateles::JSCompartment'
JSCompartment::eval(const std::string& script, std::vector<std::string>& args)
               ^~~~
/usr/local/ateles/c_src/js.cc:191:16: error: out-of-line definition of 'call' does not match any declaration in 'ateles::JSCompartment'
JSCompartment::call(const std::string& name, std::vector<std::string>& args)
               ^~~~
4 errors generated.
make[2]: *** [CMakeFiles/ateles.dir/c_src/js.cc.o] Error 1
```