### PR TITLE
Fix handling of stream_finished messages

### DIFF
--- a/src/ateles.erl
+++ b/src/ateles.erl
@@ -27,6 +27,9 @@
 ]).
 
 
+-define(RETRIES, 5).
+
+
 rewrite(Source) when is_binary(Source) ->
     with_ctx("$rewrite$", {ateles_context_rewrite_fun, nil}, fun(Ctx) ->
         ateles_context_rewrite_fun:rewrite(Ctx, Source)
@@ -54,20 +57,44 @@ release_map_context(Ctx) ->
 
 
 map_docs(Ctx, Docs) ->
+    map_docs(Ctx, Docs, ?RETRIES).
+
+
+map_docs(_Ctx, _Docs, Retries) when Retries =< 0 ->
+    erlang:error({map_docs_failed, retries_exhausted});
+
+map_docs(Ctx, Docs, Retries) ->
     Refs = lists:map(fun(Doc) ->
         Json = couch_doc:to_json_obj(Doc, []),
         ateles_context_map:map_doc_async(Ctx, Json)
     end, Docs),
-    {ok, lists:zipwith(fun(Ref, #doc{id = DocId}) ->
-        {ok, Results} = ateles_context_map:map_doc_recv(Ref),
-        Tupled = lists:map(fun(ViewResults) ->
-            lists:map(fun
-                ([K, V]) -> {K, V};
-                (Error) when is_binary(Error) -> Error
-            end, ViewResults)
-        end, Results),
-        {DocId, Tupled}
-    end, Refs, Docs)}.
+    try
+        map_docs(Ctx, Docs, Refs, [])
+    catch throw:retry ->
+        map_docs(Ctx, Docs, Retries - 1)
+    end.
+
+
+map_docs(_Ctx, [], [], Acc) ->
+    {ok, lists:reverse(Acc)};
+
+map_docs(Ctx, [Doc | RestDocs], [Ref | RestRefs], Acc) ->
+    case ateles_context_map:map_doc_recv(Ref) of
+        {ok, Results} ->
+            Tupled = lists:map(fun(ViewResults) ->
+                lists:map(fun
+                    ([K, V]) -> {K, V};
+                    (Error) when is_binary(Error) -> Error
+                end, ViewResults)
+            end, Results),
+            NewAcc = [{Doc#doc.id, Tupled} | Acc],
+            map_docs(Ctx, RestDocs, RestRefs, NewAcc);
+        {error, Reason} ->
+            erlang:error(Reason);
+        stream_finished ->
+            drain_refs(RestRefs),
+            throw(retry)
+    end.
 
 
 with_ctx(CtxId, CtxInfo, Fun) ->
@@ -77,3 +104,12 @@ with_ctx(CtxId, CtxInfo, Fun) ->
     after
         ateles_server:release_context(Ctx)
     end.
+
+
+drain_refs([]) ->
+    ok;
+
+drain_refs([Ref | Rest]) ->
+    ateles_context_map:map_doc_recv(Ref),
+    drain_refs(Rest).
+


### PR DESCRIPTION
It appears that gRPC++ has an idle stream timeout. This update handles
receiving unexpected stream exits (most likely when a stream is re-used
after having been idle for awhile).