### PR TITLE
Limit JS execution time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ priv/ateles
 
 src/ateles_client.erl
 src/ateles_pb.erl
+src/grpc_health_v_1_health_client.erl
+src/health_pb.erl

--- a/c_src/errors.h
+++ b/c_src/errors.h
@@ -76,6 +76,16 @@ class AtelesResourceExhaustedError : public AtelesError {
     }
 };
 
+class AtelesTimeoutError : public AtelesError {
+public:
+    explicit AtelesTimeoutError(const std::string& what) : AtelesError(what) {}
+
+    virtual grpc::StatusCode code() const throw()
+    {
+        return grpc::StatusCode::DEADLINE_EXCEEDED;
+    }
+};
+
 class AtelesInternalError : public AtelesError {
   public:
     explicit AtelesInternalError(const std::string& what) : AtelesError(what) {}

--- a/c_src/server.cc
+++ b/c_src/server.cc
@@ -306,7 +306,11 @@ Connection::handle_request()
     }
 
     try {
-        JSCxAutoTimeout auto_to(this->_cx, 5000);
+        int timeout = this->_req.timeout();
+        if(timeout <= 0) {
+            timeout = 5000;
+        }
+        JSCxAutoTimeout auto_to(this->_cx, timeout);
 
         std::string result;
         if(this->_req.action() == JSRequest_Action_EVAL) {

--- a/c_src/server.cc
+++ b/c_src/server.cc
@@ -306,6 +306,8 @@ Connection::handle_request()
     }
 
     try {
+        JSCxAutoTimeout auto_to(this->_cx, 5000);
+
         std::string result;
         if(this->_req.action() == JSRequest_Action_EVAL) {
             result = this->_compartment->eval(this->_req.script(), args);

--- a/proto/ateles.proto
+++ b/proto/ateles.proto
@@ -25,6 +25,7 @@ message JSRequest {
     Action action = 1;
     string script = 2;
     repeated string args = 3;
+    int32 timeout = 4;
 }
 
 

--- a/src/ateles_util.erl
+++ b/src/ateles_util.erl
@@ -16,8 +16,11 @@
 
 -export([
     eval/3,
+    eval/4,
     call/3,
+    call/4,
     call_async/3,
+    call_async/4,
     handle_async_resp/2,
 
     eval_file/2,
@@ -32,13 +35,18 @@
 
 
 eval(Stream, FileName, Script) ->
+    eval(Stream, FileName, Script, 5000).
+
+
+eval(Stream, FileName, Script, Timeout) ->
     Req = #{
         action => 0,
         script => Script,
         args => [
             list_to_binary("file=" ++ FileName),
             <<"line=1">>
-        ]
+        ],
+        timeout => Timeout
     },
     ok = grpcbox_client:send(Stream, Req),
     {ok, Resp} = grpcbox_client:recv_data(Stream, infinity),
@@ -51,10 +59,15 @@ eval(Stream, FileName, Script) ->
 
 
 call(Stream, Function, Args) ->
+    call(Stream, Function, Args, 5000).
+
+
+call(Stream, Function, Args, Timeout) ->
     Req = #{
         action => 1,
         script => Function,
-        args => lists:map(fun jiffy:encode/1, Args)
+        args => lists:map(fun jiffy:encode/1, Args),
+        timeout => Timeout
     },
     ok = grpcbox_client:send(Stream, Req),
     case grpcbox_client:recv_data(Stream, infinity) of
@@ -68,10 +81,15 @@ call(Stream, Function, Args) ->
 
 
 call_async(Stream, Function, Args) ->
+    call_async(Stream, Function, Args, 5000).
+
+
+call_async(Stream, Function, Args, Timeout) ->
     Req = #{
         action => 1,
         script => Function,
-        args => lists:map(fun jiffy:encode/1, Args)
+        args => lists:map(fun jiffy:encode/1, Args),
+        timeout => Timeout
     },
     ok = grpcbox_client:send(Stream, Req).
 

--- a/test/ateles_timeout_tests.erl
+++ b/test/ateles_timeout_tests.erl
@@ -1,0 +1,72 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(ateles_timeout_tests).
+
+
+-include_lib("eunit/include/eunit.hrl").
+
+
+-define(TDEF(A), {atom_to_list(A), fun A/0}).
+
+
+timeout_test_() ->
+    {
+        "Timeout tests",
+        {
+            setup,
+            fun() -> test_util:start_couch([ateles]) end,
+            fun test_util:stop_couch/1,
+            [
+                {timeout, 10, ?TDEF(timeout_eval_default)},
+                ?TDEF(timeout_eval_control),
+                ?TDEF(timeout_call)
+            ]
+        }
+    }.
+
+
+timeout_eval_default() ->
+    % The settings ack frame apparently isn't returned until
+    % the first user generated frame is returned so we have
+    % to run a first quick exchange so that chatterbox doesn't
+    % blow up due to not setting the settings ack.
+    {ok, Stream} = ateles_client:execute(#{channel => ateles}),
+    Result1 = ateles_util:eval(Stream, <<"foo.js">>, <<"var b = 12;">>),
+    ?assertMatch({ok, _}, Result1),
+
+    Script = <<"(function() {while(1) {continue;}})();">>,
+    Result2 = ateles_util:eval(Stream, <<"foo.js">>, Script, 0),
+    ?assertMatch({error, {4, <<"Time out", _/binary>>}}, Result2),
+    grpcbox_client:close_and_recv(Stream).
+
+
+timeout_eval_control() ->
+    {ok, Stream} = ateles_client:execute(#{channel => ateles}),
+    Result1 = ateles_util:eval(Stream, <<"foo.js">>, <<"var b = 12;">>),
+    ?assertMatch({ok, _}, Result1),
+
+    Script = <<"(function() {while(1) {continue;}})();">>,
+    Result2 = ateles_util:eval(Stream, <<"foo.js">>, Script, 250),
+    ?assertMatch({error, {4, <<"Time out", _/binary>>}}, Result2),
+    grpcbox_client:close_and_recv(Stream).
+
+
+timeout_call() ->
+    {ok, Stream} = ateles_client:execute(#{channel => ateles}),
+    Script = <<"function wait() {var a = 1; while(true) {a += 1;}};">>,
+    Result1 = ateles_util:eval(Stream, <<"foo.js">>, Script),
+    ?assertMatch({ok, _}, Result1),
+
+    Result2 = ateles_util:call(Stream, <<"wait">>, [], 250),
+    ?assertMatch({error, {4, <<"Time out", _/binary>>}}, Result2),
+    grpcbox_client:close_and_recv(Stream).


### PR DESCRIPTION
This currently sets a five second timeout on all JavaScript execution requests. Any JS that takes longer than that will return with a time out error.

I've also updated the protocol so that eventually we'll be able to selectively tweak timeouts for individual JS Contexts. Adding the configuration on the Erlang side is a TODO item.