### PR TITLE
Fix double eval

### DIFF
--- a/c_src/js.cc
+++ b/c_src/js.cc
@@ -103,7 +103,8 @@ JSCx::JSCx(size_t max_mem, bool rewriter) :
     _cx_mgr(create_jscontext(max_mem), JS_DestroyContext),
     _wd_alive(true),
     _wd_active(false),
-    _last_gc_bytes(0)
+    _last_gc_bytes(0),
+    _num_evals(0)
 {
     this->_cx = this->_cx_mgr.get();
 
@@ -197,6 +198,13 @@ JSCx::eval(const std::string& script, std::vector<std::string>& args)
         } else {
             throw AtelesInvalidArgumentError("Unknown eval option: " + key);
         }
+    }
+
+    // TODO: Remove this after we debug why
+    //       map.js is being loaded multiple times.
+    if(file == "map.js") {
+        _num_evals++;
+        fprintf(stderr, "xkcd: map.js loaded %d times: %p\n", _num_evals, this);
     }
 
     JS::RootedValue rval(this->_cx);

--- a/c_src/js.h
+++ b/c_src/js.h
@@ -56,6 +56,10 @@ class JSCx {
     // Memory reporting
     void set_memory_gauge();
     uint64_t _last_gc_bytes;
+
+    // TODO: Remove after debugging why we're loading
+    //       map.js multiple times into a context.
+    int _num_evals;
 };
 
 class JSCxAutoTimeout {

--- a/c_src/util.cc
+++ b/c_src/util.cc
@@ -68,6 +68,12 @@ void
 report_error(const char* opname, boost::system::error_code& ec)
 {
     const char* fmt = "error: %s [%d] %s - %s\n";
+
+    if(ec.value() == 1) {
+        // Don't log closures due to timeouts
+        return;
+    }
+
     fprintf(stderr,
         fmt,
         opname,

--- a/rebar.config
+++ b/rebar.config
@@ -33,4 +33,7 @@
     verbose
 ]}.
 
+{cover_enabled, true}.
+{cover_print_enabled, true}.
+
 {pre_hooks, [{"", compile, "make server"}]}.

--- a/src/ateles.erl
+++ b/src/ateles.erl
@@ -44,8 +44,14 @@ acquire_map_context(CtxOpts) ->
 
     InitClosure = fun(Ctx) ->
         {ok, MapFuns} = ateles_util:rewrite(Ctx, RawMapFuns),
-        {ok, _} = ateles_util:eval_file(Ctx, "map.js"),
-        {ok, true} = ateles_util:call(Ctx, <<"init">>, [Lib, MapFuns])
+        case ateles_util:eval_file(Ctx, "map.js") of
+            {ok, _} ->
+                Args = [Lib, MapFuns],
+                {ok, true} = ateles_util:call(Ctx, <<"init">>, Args),
+                ok;
+            {error, _} = Error ->
+                Error
+        end
     end,
     ateles_server:acquire(CtxId, InitClosure).
 

--- a/src/ateles_util.erl
+++ b/src/ateles_util.erl
@@ -103,15 +103,7 @@ eval_file(Ctx, FileName) when is_list(FileName) ->
 
 
 load_file(FileName) when is_list(FileName) ->
-    PrivDir = case code:priv_dir(?MODULE) of
-        {error, _} ->
-            EbinDir = filename:dirname(code:which(?MODULE)),
-            AppPath = filename:dirname(EbinDir),
-            filename:join(AppPath, "priv");
-        PDir ->
-            PDir
-    end,
-    Path = filename:join(PrivDir, FileName),
+    Path = filename:join(priv_dir(), FileName),
     {ok, Data} = file:read_file(Path),
     Data.
 
@@ -154,17 +146,8 @@ ensure_server() ->
     end.
 
 
-run_server() ->
-    AppDir = case code:priv_dir(?MODULE) of
-        {error, _} ->
-            EbinDir = filename:dirname(code:which(?MODULE)),
-            filename:dirname(EbinDir);
-        Path ->
-            Path
-    end,
-    PrivDir = filename:join(AppDir, "priv"),
-
-    Command = filename:join(PrivDir, "ateles"),
+run_server(Parent) ->
+    Command = filename:join(priv_dir(), "ateles"),
     Host = config:get("ateles", "service_url", "127.0.0.1"),
     Port = config:get("atelese", "service_port", "8444"),
 
@@ -187,4 +170,15 @@ server_loop(Port) ->
             server_loop(Port);
         Error ->
             io:format(standard_error, "SERVER ERROR: ~p~n", [Error])
+    end.
+
+
+priv_dir() ->
+    case code:priv_dir(ateles) of
+        {error, _} ->
+            EbinDir = filename:dirname(code:which(?MODULE)),
+            AppPath = filename:dirname(EbinDir),
+            filename:join(AppPath, "priv");
+        PrivDir ->
+            PrivDir
     end.

--- a/test/ateles_acquire_release_tests.erl
+++ b/test/ateles_acquire_release_tests.erl
@@ -36,7 +36,9 @@ acquire_release_test_() ->
             fun test_util:stop_couch/1,
             [
                 ?TDEF(acquire_release),
-                ?TDEF(acquire_multiple)
+                ?TDEF(acquire_multiple),
+                ?TDEF(acquire_error),
+                ?TDEF(acquire_exception)
             ]
         }
     }.
@@ -60,4 +62,22 @@ acquire_multiple() ->
     ?assertEqual(1, length(ets:lookup(?CLIENTS, self()))),
 
     ok = ateles_server:release(Ctx2),
+    ?assertEqual(0, length(ets:lookup(?CLIENTS, self()))).
+
+
+acquire_error() ->
+    Init = fun(_) -> {error, on_purpose} end,
+    ?assertEqual(
+            {error, on_purpose},
+            ateles_server:acquire(error_id, Init)
+        ),
+    ?assertEqual(0, length(ets:lookup(?CLIENTS, self()))).
+
+
+acquire_exception() ->
+    Init = fun(_) -> erlang:throw(on_purpose) end,
+    ?assertMatch(
+            {error, {throw, on_purpose, _}},
+            ateles_server:acquire(exception_id, Init)
+        ),
     ?assertEqual(0, length(ets:lookup(?CLIENTS, self()))).


### PR DESCRIPTION
Minimize the impact of errors in ateles_server when creating JS contexts fails. Also add logging to attempt to diagnose why those errors are happening in the first place. And a couple unit test fixes exposed by running on Erlang 22.