### PR TITLE
Execute Javascript when processing _health endpoint request

### DIFF
--- a/c_src/connection.cc
+++ b/c_src/connection.cc
@@ -123,7 +123,14 @@ Connection::do_read()
             }
 
             if(_req.method() == http::verb::get && _req.target() == "/Health") {
-                respond(http::status::ok, "OK");
+                if(!_context) {
+                    _context = std::make_shared<JSWorker>(_max_mem);
+                }
+                Message::Ptr mesg = Message::create(self, _req.body());
+
+                auto req = mesg->get_request();
+                req->set_action(JSRequest::HEALTHCHECK);
+                _context->submit(mesg);
                 return;
             }
 

--- a/c_src/js_worker.cc
+++ b/c_src/js_worker.cc
@@ -86,6 +86,9 @@ JSWorker::run_one(JSCx* jscx)
             resp = jscx->call(req->script(), args);
         } else if(req->action() == JSRequest::CALL) {
             resp = jscx->call(req->script(), args);
+        } else if(req->action() == JSRequest::HEALTHCHECK) {
+            std::string script("var x = 'OK'; x;");
+            resp = jscx->eval(script, args);
         }
         ATELES_STAT_JS_SUCCESS++;
         msg->set_response(0, resp);

--- a/proto/ateles.proto
+++ b/proto/ateles.proto
@@ -22,6 +22,9 @@ message JSRequest {
         REWRITE = 0;
         EVAL = 1;
         CALL = 2;
+        // introduce HEALTHCHECK so that the _health endpoint call
+        // can be treated as internal healthcheck action
+        HEALTHCHECK = 3;
     }
     Action action = 1;
     string script = 2;

--- a/test/ateles_health_check_test.py
+++ b/test/ateles_health_check_test.py
@@ -1,0 +1,39 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+import requests
+import unittest
+
+
+class HealthChecker(object):
+
+    def __init__(self, host, port):
+        self.host = host
+        self.port = port
+
+    def get_result(self):
+        addr = "{}:{}/Health".format(self.host, self.port)
+        return requests.get("http://{}".format(addr))
+
+
+class TestHealthCheck(unittest.TestCase):
+
+    @classmethod
+    def setUp(cls):
+        cls.hc = HealthChecker("localhost", "50051")
+
+    def test(self):
+        r = self.hc.get_result()
+        assert (r.status_code == 200)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
In order to improve the quality of liveness check of ateles, execute Javascript when processing _health endpoint request.

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->


## Testing recommendations

```
python ateles_health_check_test.py
.
----------------------------------------------------------------------
Ran 1 test in 0.034s

OK
```

Working on more test

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

https://github.ibm.com/cloudant/fdb-dbcore/issues/538


