### PR TITLE
Update boost location (bintray is no longer available)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ else()
     message(STATUS "Building boost 1.72")
     include(ExternalProject)
     ExternalProject_add(boost
-        URL "https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2"
+        URL "https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2"
         URL_HASH SHA256=59c9b274bc451cf91a9ba1dd2c7fdcaf5d60b1b3aa83f2c9fa143417cc660722
         DOWNLOAD_NO_PROGRESS ON
         CONFIGURE_COMMAND ./bootstrap.sh --with-libraries=thread


### PR DESCRIPTION
bintray.com service is no longer provided by JFrog (see red banner on https://bintray.com/). 

The new link was taken from official web site https://www.boost.org/users/history/.

I tested downloaded file to make sure sha256 is the same.
