### PR TITLE
Change get_stacktrace/0 to try/catch syntax for stacktrace

### DIFF
--- a/src/ateles_server.erl
+++ b/src/ateles_server.erl
@@ -35,6 +35,9 @@
 ]).
 
 
+-include_lib("couch/include/couch_db.hrl").
+
+
 -define(CONTEXTS, ateles_server_contexts).
 -define(CLIENTS, ateles_server_clients).
 -define(LRU, ateles_server_lru).
@@ -226,8 +229,7 @@ acquire_int(CtxId, InitClosure, #{max_contexts := MaxContexts} = St) ->
                     Fmt = "Failed to initialize ateles context: ~p",
                     couch_log:error(Fmt, [Reason]),
                     Error
-            catch T:R ->
-                S = erlang:get_stacktrace(),
+            catch ?STACKTRACE(T, R, S) ->,
                 Fmt = "Failed to initialize ateles context: ~p",
                 couch_log:error(Fmt, [{T, R, S}]),
                 {error, {T, R, S}}

--- a/src/ateles_server.erl
+++ b/src/ateles_server.erl
@@ -229,7 +229,7 @@ acquire_int(CtxId, InitClosure, #{max_contexts := MaxContexts} = St) ->
                     Fmt = "Failed to initialize ateles context: ~p",
                     couch_log:error(Fmt, [Reason]),
                     Error
-            catch ?STACKTRACE(T, R, S) ->,
+            catch ?STACKTRACE(T, R, S)
                 Fmt = "Failed to initialize ateles context: ~p",
                 couch_log:error(Fmt, [{T, R, S}]),
                 {error, {T, R, S}}

--- a/src/ateles_util.erl
+++ b/src/ateles_util.erl
@@ -32,6 +32,8 @@
 ]).
 
 
+-include_lib("couch/include/couch_db.hrl").
+
 
 create_ctx() ->
     EndPoint = get_endpoint(),
@@ -168,8 +170,7 @@ run_server(Parent) ->
         ServerPort = erlang:open_port({spawn_executable, Command}, Args),
         Parent ! {self(), ready},
         server_loop(ServerPort)
-    catch T:R ->
-        S = erlang:get_stacktrace(),
+    catch ?STACKTRACE(T, R, S) ->
         io:format(standard_error, "SERVER ERROR: ~p:~p~n~p~n~n", [T, R, S])
     end.
 

--- a/src/ateles_util.erl
+++ b/src/ateles_util.erl
@@ -170,7 +170,7 @@ run_server(Parent) ->
         ServerPort = erlang:open_port({spawn_executable, Command}, Args),
         Parent ! {self(), ready},
         server_loop(ServerPort)
-    catch ?STACKTRACE(T, R, S) ->
+    catch ?STACKTRACE(T, R, S)
         io:format(standard_error, "SERVER ERROR: ~p:~p~n~p~n~n", [T, R, S])
     end.
 


### PR DESCRIPTION
# Overview
Change the deprecated `get_stacktrace/0` to try/catch syntax. The try/catch syntax uses the `?STACKTRACE` macro found in `couch/include/couch_db.hrl`.

# Testing Recommendations
Compile dbcore and ensure that deprecation warnings for `get_stacktrace/0` are no longer given.

# Related Issues or Pull Requests
This is related to the ongoing upgrade to Erlang/OTP 23 (https://github.ibm.com/cloudant/fdb-dbcore/issues/690).