### PR TITLE
Upgrade ateles build to use python3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ pkg_check_modules(MOZJS REQUIRED mozjs-60)
 pkg_check_modules(PROTOBUF REQUIRED protobuf)
 
 find_program(PROTOC protoc)
-find_program(PYTHON python)
+find_program(PYTHON python3)
 
 option(ENABLE_COVERAGE "Build for code coverage reports" OFF)
 

--- a/tools/mkheader.py
+++ b/tools/mkheader.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
 # the License at
@@ -16,8 +16,8 @@ import sys
 
 def make_bytes(src):
     for line in src:
-        for c in line:
-            yield "0x{:02x}".format(ord(c))
+        for b in line:
+            yield "0x{:02x}".format(b)
 
 
 def mkheader(base_varname, src, tgt):
@@ -43,11 +43,11 @@ def mkheader(base_varname, src, tgt):
 
 def main():
     if len(sys.argv) != 4:
-        print "usage: %s infile outfile base_varname" % sys.argv[0]
+        print("usage: %s infile outfile base_varname" % sys.argv[0])
         exit(1)
 
-    with open(sys.argv[1]) as src:
-        with open(sys.argv[2], "wb") as tgt:
+    with open(sys.argv[1], "rb") as src:
+        with open(sys.argv[2], "w", encoding="ascii") as tgt:
             mkheader(sys.argv[3], src, tgt)
 
 


### PR DESCRIPTION
## Overview
Convert Ateles python scripts from python2 to python3.

## Testing recommendations
Open 2 terminals and go to the specified folder, and then run the following commands.

```
fdb-dbcore/src/ateles $ ./_build/ateles -f 10  -p 8444
fdb-dbcore $ make check apps=ateles
```

## Related Issues or Pull Requests
To fix [#704](https://github.ibm.com/cloudant/fdb-dbcore/issues/704)