### PR TITLE
remove use of ?STACKTRACE macro

### DIFF
--- a/src/ateles_server.erl
+++ b/src/ateles_server.erl
@@ -229,7 +229,7 @@ acquire_int(CtxId, InitClosure, #{max_contexts := MaxContexts} = St) ->
                     Fmt = "Failed to initialize ateles context: ~p",
                     couch_log:error(Fmt, [Reason]),
                     Error
-            catch ?STACKTRACE(T, R, S)
+            catch T:R:S ->
                 Fmt = "Failed to initialize ateles context: ~p",
                 couch_log:error(Fmt, [{T, R, S}]),
                 {error, {T, R, S}}

--- a/src/ateles_util.erl
+++ b/src/ateles_util.erl
@@ -170,7 +170,7 @@ run_server(Parent) ->
         ServerPort = erlang:open_port({spawn_executable, Command}, Args),
         Parent ! {self(), ready},
         server_loop(ServerPort)
-    catch ?STACKTRACE(T, R, S)
+    catch T:R:S ->
         io:format(standard_error, "SERVER ERROR: ~p:~p~n~p~n~n", [T, R, S])
     end.
 


### PR DESCRIPTION
The `?STACKTRACE` is no longer used in CouchDB. This is causing a build error with Ateles. 