### PR TITLE
Validate doc update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,8 @@ set(ESPRIMA_SRC ${CMAKE_CURRENT_SOURCE_DIR}/priv/esprima.js)
 set(ESPRIMA_HDR ${CMAKE_CURRENT_BINARY_DIR}/esprima.h)
 set(REWRITE_SRC ${CMAKE_CURRENT_SOURCE_DIR}/priv/rewrite_fun.js)
 set(REWRITE_HDR ${CMAKE_CURRENT_BINARY_DIR}/rewrite_fun.h)
+set(VALIDATE_SRC ${CMAKE_CURRENT_SOURCE_DIR}/priv/validate.js)
+set(VALIDATE_HDR ${CMAKE_CURRENT_BINARY_DIR}/validate.h)
 
 
 add_custom_command(
@@ -106,6 +108,12 @@ add_custom_command(
     DEPENDS ${REWRITE_SRC}
 )
 
+add_custom_command(
+        OUTPUT ${VALIDATE_HDR}
+        COMMAND ${PYTHON} ${MKHEADER} ${VALIDATE_SRC} ${VALIDATE_HDR} validate
+        DEPENDS ${VALIDATE_SRC}
+)
+
 
 file(GLOB SRC "c_src/*.cc")
 add_executable(
@@ -114,7 +122,8 @@ add_executable(
     ${SRC}
     ${ESCODEGEN_HDR}
     ${ESPRIMA_HDR}
-    ${REWRITE_HDR})
+    ${REWRITE_HDR}
+    ${VALIDATE_HDR})
 
 set(CFLAGS
     -g

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-.PHONY: all format init build test coverage clean
+.PHONY: all format init build test coverage clean dev-run
 
 all: server
 	@rebar compile
@@ -34,6 +34,8 @@ server: init
 	@mkdir -p priv/
 	@cp _build/ateles priv/ateles
 
+dev-run: server
+	_build/ateles -p 8444
 
 eunit: export ERL_AFLAGS = -config $(shell pwd)/test/eunit.config
 eunit:

--- a/c_src/js.cc
+++ b/c_src/js.cc
@@ -20,6 +20,7 @@
 #include "esprima.h"
 #include "js/Conversions.h"
 #include "rewrite_fun.h"
+#include "validate.h"
 #include "stats.h"
 
 #define ACTIVE_SLEEP_TIME_MSEC 100   // 100ms = 0.1s
@@ -129,6 +130,10 @@ JSCx::JSCx(size_t max_mem, bool rewriter) :
     if(!JS_DefineFunction(this->_cx, global_obj, "print", print_fun, 1, 0)) {
         throw AtelesInternalError("Error installing print function.");
     }
+
+    auto validate_src = std::string((const char*) validate_data, validate_len);
+    auto args = std::vector<std::string>{"file=validate.js"};
+    this->eval(validate_src, args);
 
     if(rewriter) {
         std::string src((const char*) escodegen_data, escodegen_len);

--- a/priv/validate.js
+++ b/priv/validate.js
@@ -1,0 +1,19 @@
+
+let isArray = Array.isArray;
+
+function validate(funStr, ddocStr, argsStr) {
+    try {
+        const ddoc = JSON.parse(ddocStr);
+        const args = JSON.parse(argsStr);
+        const fun = eval(JSON.parse(funStr))
+        fun.apply(ddoc, args);
+        return true;
+    } catch (error) {
+        if (error.name && error.message) {
+            return {
+                compilation_error: error.toString()
+            }
+        }
+        return error;
+    }
+}

--- a/test/ateles_acquire_release_tests.erl
+++ b/test/ateles_acquire_release_tests.erl
@@ -14,9 +14,7 @@
 
 
 -include_lib("eunit/include/eunit.hrl").
-
-
--define(TDEF(A), {atom_to_list(A), fun A/0}).
+-include_lib("fabric/test/fabric2_test.hrl").
 
 
 -define(CONTEXTS, ateles_server_contextss).
@@ -34,24 +32,24 @@ acquire_release_test_() ->
             setup,
             fun() -> test_util:start_couch([ateles]) end,
             fun test_util:stop_couch/1,
-            [
+            with([
                 ?TDEF(acquire_release),
                 ?TDEF(acquire_multiple),
                 ?TDEF(acquire_error),
                 ?TDEF(acquire_exception)
-            ]
+            ])
         }
     }.
 
 
-acquire_release() ->
+acquire_release(_) ->
     {ok, Ctx} = ateles_server:acquire(?CTX_ID, ?INIT_CLOSURE),
     ?assertEqual(1, length(ets:lookup(?CLIENTS, self()))),
     ok = ateles_server:release(Ctx),
     ?assertEqual(0, length(ets:lookup(?CLIENTS, self()))).
 
 
-acquire_multiple() ->
+acquire_multiple(_) ->
     {ok, Ctx1} = ateles_server:acquire(?CTX_ID, ?INIT_CLOSURE),
     {ok, Ctx2} = ateles_server:acquire(?CTX_ID, ?INIT_CLOSURE),
 
@@ -65,7 +63,7 @@ acquire_multiple() ->
     ?assertEqual(0, length(ets:lookup(?CLIENTS, self()))).
 
 
-acquire_error() ->
+acquire_error(_) ->
     Init = fun(_) -> {error, on_purpose} end,
     ?assertEqual(
             {error, on_purpose},
@@ -74,7 +72,7 @@ acquire_error() ->
     ?assertEqual(0, length(ets:lookup(?CLIENTS, self()))).
 
 
-acquire_exception() ->
+acquire_exception(_) ->
     Init = fun(_) -> erlang:throw(on_purpose) end,
     ?assertMatch(
             {error, {throw, on_purpose, _}},

--- a/test/ateles_basic_tests.erl
+++ b/test/ateles_basic_tests.erl
@@ -14,9 +14,7 @@
 
 
 -include_lib("eunit/include/eunit.hrl").
-
-
--define(TDEF(A), {atom_to_list(A), fun A/0}).
+-include_lib("fabric/test/fabric2_test.hrl").
 
 
 basic_test_() ->
@@ -26,22 +24,22 @@ basic_test_() ->
             setup,
             fun() -> test_util:start_couch([ateles]) end,
             fun test_util:stop_couch/1,
-            [
+            with([
                 ?TDEF(eval_code),
                 ?TDEF(call_function)
-            ]
+            ])
         }
     }.
 
 
-eval_code() ->
+eval_code(_) ->
     {ok, Ctx} = ateles_util:create_ctx(),
     Script = <<"var x = 2; x;">>,
     {ok, 2} = ateles_util:eval({test_ctx, Ctx}, <<"foo.js">>, Script),
     ok = ateles_util:destroy_ctx(Ctx).
 
 
-call_function() ->
+call_function(_) ->
     {ok, Ctx} = ateles_util:create_ctx(),
     Script = <<"function double(x) {return x * 2;};">>,
     {ok, _} = ateles_util:eval({test_ctx, Ctx}, <<"foo.js">>, Script),

--- a/test/ateles_map_doc_tests.erl
+++ b/test/ateles_map_doc_tests.erl
@@ -15,9 +15,7 @@
 
 -include_lib("couch/include/couch_db.hrl").
 -include_lib("eunit/include/eunit.hrl").
-
-
--define(TDEF(A), {atom_to_list(A), fun A/0}).
+-include_lib("fabric/test/fabric2_test.hrl").
 
 
 map_doc_test_() ->
@@ -27,17 +25,17 @@ map_doc_test_() ->
             setup,
             fun() -> test_util:start_couch([ateles]) end,
             fun test_util:stop_couch/1,
-            [
+            with([
                 ?TDEF(map_single_doc),
                 ?TDEF(map_single_doc_in_DBCS),
                 ?TDEF(map_doc_exception),
                 ?TDEF(map_no_funs)
-            ]
+            ])
         }
     }.
 
 
-map_single_doc() ->
+map_single_doc(_) ->
     {ok, Ctx} = ateles:acquire_map_context(single_fun_opts()),
     {ok, Results} = ateles:map_docs(Ctx, [
         #doc{id = <<"foo">>, body = {[{<<"value">>, <<"bar">>}]}}]
@@ -46,7 +44,7 @@ map_single_doc() ->
     ok = ateles:release_map_context(Ctx).
 
 
-map_single_doc_in_DBCS() ->
+map_single_doc_in_DBCS(_) ->
     {ok, Ctx} = ateles:acquire_map_context(single_fun_opts()),
     {ok, Results} = ateles:map_docs(
         Ctx, [#doc{id = <<"foo">>,
@@ -72,7 +70,7 @@ single_fun_opts() ->
     }.
 
 
-map_doc_exception() ->
+map_doc_exception(_) ->
     {ok, Ctx} = ateles:acquire_map_context(exception_opts()),
     {ok, Results} = ateles:map_docs(Ctx, [#doc{id = <<"foo">>}]),
     ?assertEqual([{<<"foo">>, [[]]}], Results),
@@ -90,7 +88,7 @@ exception_opts() ->
     }.
 
 
-map_no_funs() ->
+map_no_funs(_) ->
     {ok, Ctx} = ateles:acquire_map_context(no_funs_opts()),
     ?assertError(
             {map_docs, {{<<"missing_map_functions">>, _}, _}},

--- a/test/ateles_rewrite_fun_tests.erl
+++ b/test/ateles_rewrite_fun_tests.erl
@@ -14,9 +14,7 @@
 
 
 -include_lib("eunit/include/eunit.hrl").
-
-
--define(TDEF(A), {atom_to_list(A), fun A/0}).
+-include_lib("fabric/test/fabric2_test.hrl").
 
 
 rewrite_test_() ->
@@ -26,23 +24,23 @@ rewrite_test_() ->
             setup,
             fun() -> test_util:start_couch([ateles]) end,
             fun test_util:stop_couch/1,
-            [
+            with([
                 ?TDEF(rewrite_simple),
                 ?TDEF(rewrite_all),
                 ?TDEF(rewrite_valid)
-            ]
+            ])
         }
     }.
 
 
-rewrite_simple() ->
+rewrite_simple(_) ->
     Function = <<"function(doc) {emit(null, null);}">>,
     Expect = <<"(function (doc) {\n    emit(null, null);\n});">>,
     {ok, Result} = do_rewrite(Function),
     ?assertEqual(Expect, Result).
 
 
-rewrite_all() ->
+rewrite_all(_) ->
     Functions = [
         <<"function(doc){ emit(null, null);}">>,
         <<"function(bar){return;}">>
@@ -55,7 +53,7 @@ rewrite_all() ->
     ?assertEqual(Expect, Result).
 
 
-rewrite_valid() ->
+rewrite_valid(_) ->
     Function = <<"(function (doc) {\n    emit(null, null);\n});">>,
     {ok, Result} = do_rewrite(Function),
     ?assertEqual(Function, Result).

--- a/test/ateles_timeout_tests.erl
+++ b/test/ateles_timeout_tests.erl
@@ -14,9 +14,7 @@
 
 
 -include_lib("eunit/include/eunit.hrl").
-
-
--define(TDEF(A), {atom_to_list(A), fun A/0}).
+-include_lib("fabric/test/fabric2_test.hrl").
 
 
 timeout_test_() ->
@@ -26,16 +24,16 @@ timeout_test_() ->
             setup,
             fun() -> test_util:start_couch([ateles]) end,
             fun test_util:stop_couch/1,
-            [
-                {timeout, 10, ?TDEF(timeout_eval_default)},
+            with([
+                ?TDEF(timeout_eval_default, 10),
                 ?TDEF(timeout_eval_control),
                 ?TDEF(timeout_call)
-            ]
+            ])
         }
     }.
 
 
-timeout_eval_default() ->
+timeout_eval_default(_) ->
     {ok, Ctx} = ateles_util:create_ctx(),
     Script = <<"(function() {while(1) {continue;}})();">>,
     Result = ateles_util:eval({test_ctx, Ctx}, <<"foo.js">>, Script, 0),
@@ -43,7 +41,7 @@ timeout_eval_default() ->
     ok = ateles_util:destroy_ctx(Ctx).
 
 
-timeout_eval_control() ->
+timeout_eval_control(_) ->
     {ok, Ctx} = ateles_util:create_ctx(),
     Script = <<"(function() {while(1) {continue;}})();">>,
     Result = ateles_util:eval({test_ctx, Ctx}, <<"foo.js">>, Script, 250),
@@ -51,7 +49,7 @@ timeout_eval_control() ->
     ok = ateles_util:destroy_ctx(Ctx).
 
 
-timeout_call() ->
+timeout_call(_) ->
     {ok, Ctx} = ateles_util:create_ctx(),
     Script = <<"function wait() {var a = 1; while(true) {a += 1;}};">>,
     {ok, _} = ateles_util:eval({test_ctx, Ctx}, <<"foo.js">>, Script, 0),

--- a/test/ateles_validate_tests.erl
+++ b/test/ateles_validate_tests.erl
@@ -1,0 +1,75 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(ateles_validate_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("fabric/test/fabric2_test.hrl").
+
+rewrite_test_() ->
+    {
+        "validate tests",
+        {
+            setup,
+            fun() -> test_util:start_couch([ateles]) end,
+            fun test_util:stop_couch/1,
+            with([
+                ?TDEF(validate_pass),
+                ?TDEF(validate_fail),
+                ?TDEF(validate_bad_js_error)
+            ])
+        }
+    }.
+
+validate_pass(_) ->
+    DDoc = create_ddoc(pass),
+    Doc1 = doc(),
+
+    Resp = ateles:validate_doc_update(DDoc, Doc1, nil, {[]}, {[]}),
+    ?assertEqual(Resp, ok).
+
+validate_fail(_) ->
+    DDoc = create_ddoc(fail),
+    Doc1 = doc(),
+
+    ?assertThrow({forbidden, _}, ateles:validate_doc_update(DDoc, Doc1, nil, {[]}, {[]})).
+
+validate_bad_js_error(_) ->
+    DDoc = create_ddoc(bad_js),
+    Doc1 = doc(),
+
+    ?assertThrow({compilation_error, _}, ateles:validate_doc_update(DDoc, Doc1, nil, {[]}, {[]})).
+
+doc() ->
+    couch_doc:from_json_obj(
+        {[
+            {<<"_id">>, <<"doc-id">>},
+            {<<"val">>, <<"value">>}
+        ]}
+    ).
+
+create_ddoc(pass) ->
+    JSFun = <<"function(newDoc, oldDoc, userCtx, secObj) {}">>,
+    create_ddoc(JSFun);
+create_ddoc(fail) ->
+    JSFun = <<"function(newDoc, oldDoc, userCtx, secObj) {throw({forbidden: 'Only admins may delete other user docs.'});}">>,
+    create_ddoc(JSFun);
+create_ddoc(bad_js) ->
+    JSFun = <<"function(newDoc, oldDoc, userCtx, secObj) { newDoc.this_does_not_exist() }">>,
+    create_ddoc(JSFun);
+create_ddoc(JSFun) ->
+    couch_doc:from_json_obj(
+        {[
+            {<<"_id">>, <<"_design/doc">>},
+            {<<"validate_doc_update">>, JSFun}
+        ]}
+    ).


### PR DESCRIPTION
This adds the ability to perform the `validate_doc_update` check in Ateles. 

To test this, you need the following couchdb branch https://github.com/apache/couchdb/pull/3676

Then to get Ateles running with CouchDB add the following changes to CouchDB

```diff
diff --git a/rebar.config.script b/rebar.config.script
index 98fdcfdc7..c768cb5a9 100644
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -159,7 +159,8 @@ DepDescs = [
 {meck,             "meck",             {tag, "0.9.2"}},
 {recon,            "recon",            {tag, "2.5.0"}},
 {passage,          "passage",          {tag, "CouchDB-0.2.6-1"}},
-{thrift_protocol,  "thrift-protocol",  {tag, "0.1.5"}}
+{thrift_protocol,  "thrift-protocol",  {tag, "0.1.5"}},
+{ateles, {url, "https://github.com/cloudant-labs/ateles"}, {branch, "validate-doc-update"}}
 ].
 
 WithProper = lists:keyfind(with_proper, 1, CouchConfig) == {with_proper, true}.
diff --git a/rel/overlay/etc/default.ini b/rel/overlay/etc/default.ini
index a65d667dc..5a549f154 100644
--- a/rel/overlay/etc/default.ini
+++ b/rel/overlay/etc/default.ini
@@ -343,7 +343,7 @@ bind_address = 127.0.0.1
 ; The list of modules that implement the couch_eval
 ; beahvior for executing provided code in design
 ; documents.
-;javascript = couch_js
+javascript = ateles
 ;query = mango_eval
 
 [mango]
diff --git a/rel/reltool.config b/rel/reltool.config
index a1cc938c1..288350150 100644
--- a/rel/reltool.config
+++ b/rel/reltool.config
@@ -58,6 +58,7 @@
         passage,
         thrift_protocol,
         couch_prometheus,
+        ateles,
         %% extra
         recon
     ]},
@@ -115,6 +116,7 @@
     {app, passage, [{incl_cond, include}]},
     {app, thrift_protocol, [{incl_cond, include}]},
     {app, couch_prometheus, [{incl_cond, include}]},
+    {app, ateles, [{incl_cond, include}]},
 
     %% extra
     {app, recon, [{incl_cond, include}]}
```

All couchdb tests should pass. And all js tests should fail if Ateles is not running.

The documentation on [validation doc updates](https://docs.couchdb.org/en/stable/ddocs/ddocs.html#validate-document-update-functions_)

