### PR TITLE
rename validate to validate_doc_update

### DIFF
--- a/priv/ddoc.js
+++ b/priv/ddoc.js
@@ -9,7 +9,7 @@ const jsonizeParams = (funStr, ddocStr, argsStr) => {
     return [ddoc, fun, args];
 }
 
-function validate(funStr, ddocStr, argsStr) {
+function validate_doc_update(funStr, ddocStr, argsStr) {
     try {
         const [ddoc, fun, args] = jsonizeParams(funStr, ddocStr, argsStr);
         fun.apply(ddoc, args);

--- a/src/ateles.erl
+++ b/src/ateles.erl
@@ -125,7 +125,7 @@ validate_doc_update(DDoc, EditDoc, DiskDoc, UserCtx, SecObj) ->
     JsonEditDoc = couch_doc:to_json_obj(EditDoc, [revs]),
     JsonDDoc = couch_doc:to_json_obj(DDoc, []),
     JsonDiskDoc = couch_query_servers:json_doc(DiskDoc),
-    ddoc_prompt(JsonDDoc, <<"validate">>, [<<"validate_doc_update">>], [JsonEditDoc, JsonDiskDoc, UserCtx, SecObj]).
+    ddoc_prompt(JsonDDoc, <<"validate_doc_update">>, [<<"validate_doc_update">>], [JsonEditDoc, JsonDiskDoc, UserCtx, SecObj]).
 
 filter_view(DDoc, VName, Docs) ->
     Options = couch_query_servers:json_doc_options(),


### PR DESCRIPTION
One of the testy tests are failing https://github.ibm.com/cloudant/testy/blob/master/suites/design_documents/test_document_update_validation.py#L233

The test is meant to called a non-existant function `validate` and then return a 500. However in ateles the function that implements the `validate_doc_update` logic is called `validate` so the test fails. There is a chance that users might have functions called `validate` and this would cause issues with their vdu checks. So I've renamed the `validate` function to `validate_doc_update`. 